### PR TITLE
Integrate session service to session FE

### DIFF
--- a/backend/collab-service/Dockerfile
+++ b/backend/collab-service/Dockerfile
@@ -1,0 +1,29 @@
+FROM elixir:1.17
+
+WORKDIR /app
+
+# Install hex and rebar
+RUN mix local.hex --force && \
+  mix local.rebar --force
+
+# Copy mix files
+COPY mix.exs mix.lock* ./
+
+# Get dependencies
+RUN mix deps.get
+
+# Copy source code
+COPY . .
+
+# Set environment variables
+ENV JWT_SECRET=test
+ENV MIX_ENV=dev
+ENV PHX_HOST=0.0.0.0
+
+# Compile dependencies and application
+RUN mix deps.compile
+RUN mix compile
+
+EXPOSE 4000
+
+CMD ["mix", "phx.server"]

--- a/backend/collab-service/lib/collab_service_web/user_socket.ex
+++ b/backend/collab-service/lib/collab_service_web/user_socket.ex
@@ -12,11 +12,48 @@ defmodule CollabServiceWeb.UserSocket do
         gid = "guest-" <> Base.url_encode64(:crypto.strong_rand_bytes(5))
         {:ok, assign(socket, :user_id, gid)}
 
-      true ->
-        case Joken.verify(token, @signer) do
-          {:ok, %{"sub" => user_id}} -> {:ok, assign(socket, :user_id, user_id)}
-          _ -> :error
+      token != nil and token != "" ->
+        case verify_user_service_token(token) do
+          {:ok, user_id} -> 
+            IO.inspect(user_id, label: "Connected user_id")
+            {:ok, assign(socket, :user_id, user_id)}
+          {:error, reason} -> 
+            IO.inspect(reason, label: "Token verification failed")
+            :error
         end
+
+      true ->
+        :error
+    end
+  end
+
+  defp verify_user_service_token(token) do
+    case Joken.verify(token, @signer) do
+      {:ok, claims} ->
+        IO.inspect(claims, label: "JWT Claims")
+        
+        # Your JWT has "id" field, not "sub" 
+        user_id = Map.get(claims, "id") || Map.get(claims, "sub") || Map.get(claims, "user_id")
+        
+        if user_id do
+          # Check if token is expired
+          case Map.get(claims, "exp") do
+            nil -> {:ok, user_id}
+            exp when is_integer(exp) ->
+              if System.system_time(:second) < exp do
+                {:ok, user_id}
+              else
+                {:error, :token_expired}
+              end
+            _ -> {:ok, user_id}
+          end
+        else
+          {:error, :no_user_id_in_token}
+        end
+      
+      {:error, reason} ->
+        IO.inspect(reason, label: "JWT verification error")
+        {:error, reason}
     end
   end
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "axios": "^1.12.2",
     "clsx": "^2.1.1",
     "lucide-react": "^0.544.0",
+    "monaco-editor": "^0.53.0",
     "phoenix": "^1.8.1",
     "radix-ui": "^1.4.3",
     "react": "^19.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "axios": "^1.12.2",
     "clsx": "^2.1.1",
     "lucide-react": "^0.544.0",
+    "phoenix": "^1.8.1",
     "radix-ui": "^1.4.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
@@ -26,6 +27,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.2.4",
     "@eslint/js": "^9.35.0",
+    "@types/phoenix": "^1.6.6",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       lucide-react:
         specifier: ^0.544.0
         version: 0.544.0(react@19.1.1)
+      monaco-editor:
+        specifier: ^0.53.0
+        version: 0.53.0
       phoenix:
         specifier: ^1.8.1
         version: 1.8.1

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       lucide-react:
         specifier: ^0.544.0
         version: 0.544.0(react@19.1.1)
+      phoenix:
+        specifier: ^1.8.1
+        version: 1.8.1
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -51,6 +54,9 @@ importers:
       '@eslint/js':
         specifier: ^9.35.0
         version: 9.36.0
+      '@types/phoenix':
+        specifier: ^1.6.6
+        version: 1.6.6
       '@types/react':
         specifier: ^19.1.13
         version: 19.1.13
@@ -1388,6 +1394,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/phoenix@1.6.6':
+    resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
+
   '@types/react-dom@19.1.9':
     resolution: {integrity: sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==}
     peerDependencies:
@@ -1932,6 +1941,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  phoenix@1.8.1:
+    resolution: {integrity: sha512-7i2a5f5y0Qhzi2g/+iuaGr4TzRt5ucqI0JeV2Q9K0swqY8L2C7CLR66RcGCpcQKGOY73B5GLKMYEl13o/9l/Cg==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3433,6 +3445,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/phoenix@1.6.6': {}
+
   '@types/react-dom@19.1.9(@types/react@19.1.13)':
     dependencies:
       '@types/react': 19.1.13
@@ -3947,6 +3961,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  phoenix@1.8.1: {}
 
   picocolors@1.1.1: {}
 

--- a/frontend/src/pages/Session/components/SessionQuestion/components/SessionEditor.tsx
+++ b/frontend/src/pages/Session/components/SessionQuestion/components/SessionEditor.tsx
@@ -1,142 +1,187 @@
 import { Editor } from "@monaco-editor/react";
 import { PlayIcon, UsersIcon } from "lucide-react";
-import { Channel, Socket } from "phoenix";
-import { useEffect, useState, useRef } from "react";
+import type { editor } from "monaco-editor";
+import { type Channel, Socket } from "phoenix";
+import { useCallback, useEffect, useRef } from "react";
 import { useAuth } from "../../../../../context/AuthContext";
+import type {
+	CodeUpdateResponse,
+	SessionJoinResponse,
+} from "../../../../../types/types";
 import { computeCodeDiff } from "../../../../../utils";
 
 interface SessionEditorProps {
-  language?: string;
+	language?: string;
 }
+
 export const SessionEditor = ({
-  language = "javascript",
+	language = "javascript",
 }: SessionEditorProps) => {
-  const [code, setCode] = useState("");
-  const { user } = useAuth();
+	const { user } = useAuth();
 
-  // Helper values that should not trigger rerenders
-  const revRef = useRef(0);
-  const shadowRef = useRef("");
-  const localApply = useRef(false);
+	// Helper values that should not trigger rerenders
+	const revRef = useRef(0);
+	const shadowRef = useRef("");
+	const localApply = useRef(false);
 
-  // Refs for connection that should persist 
-  const socketRef = useRef<Socket | null>(null);
-  const channelRef = useRef<Channel | null>(null);
+	// Refs for connection that should persist
+	const socketRef = useRef<Socket | null>(null);
+	const channelRef = useRef<Channel | null>(null);
+	const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
 
-  const WEB_SOCKET_URL = 'ws://localhost:4000/ws';
-  const token = '';
-  const sessionId = '';
+	const WEB_SOCKET_URL = "ws://localhost:4000/ws";
+	const token = localStorage.getItem("authToken");
 
-  // Init and join the channel on mount
-  useEffect(() => {
-    const socket = new Socket(WEB_SOCKET_URL, {
-      params: { token: token },
-    });
-    socket.connect();
-    socketRef.current = socket;
+	const sessionId = "";
 
-    const channel = socket.channel(`session:${sessionId}`);
-    channelRef.current = channel;
+	const handleEditorDidMount = (editor: editor.IStandaloneCodeEditor) => {
+		editorRef.current = editor;
+	};
 
-    // TODO: Type properly
-    channel.join().receive("ok", (resp: any) => {
-      console.log("Joined successfully", resp);
+	const updateEditorContent = useCallback((newContent: string) => {
+		console.log("updating editor content", newContent);
+		if (editorRef.current) {
+			const editor = editorRef.current;
+			// Save current cursor position
+			const position = editor.getPosition();
 
-      revRef.current = resp.rev || 0;
-      const initialText = resp.text || "";
-      shadowRef.current = initialText;
+			localApply.current = true;
+			editor.setValue(newContent);
 
-      localApply.current = true;
-      setCode(initialText);
-    }).receive("error", (resp: any) => {
-      console.log("Unable to join", resp);
-    });
+			const totalLines = editor.getModel()?.getLineCount() || 1;
+			// Restore cursor position
+			if (position && position.lineNumber <= totalLines) {
+				editor.setPosition(position);
+			}
+		}
+	}, []);
 
-    // TODO: Type properly
-    // Initialise update listener (only once)
-    channel.on("code:update", (response: any) => {
-      console.log("Update response:", response);
-      const { rev: newRev, delta, by } = response;
-      revRef.current = newRev;
+	// Init and join the channel on mount
+	useEffect(() => {
+		const socket = new Socket(WEB_SOCKET_URL, {
+			params: { token: token },
+		});
+		socket.connect();
+		socketRef.current = socket;
 
-      const shadowLeft = shadowRef.current.slice(0, delta.from);
-      const shadowRight = shadowRef.current.slice(delta.to);
-      shadowRef.current = shadowLeft + delta.text + shadowRight;
-          
+		const channel = socket.channel(`session:${sessionId}`);
+		channelRef.current = channel;
 
-      if (by !== user?.id) {
-        localApply.current = true;
-        setCode(currentCode => {
-          console.log("currentCode:", currentCode);
-          console.log("Delta:", delta);
-          const left = currentCode.slice(0, delta.from);
-          const right = currentCode.slice(delta.to);
-          const newCode = left + delta.text + right;
-          
-          return newCode;
-        });
-      }
-    })
-    channel.on("code:snapshot", ({rev: newRev, text}: {rev: number, text: string}) => {
-      localApply.current = true;
-      setCode(text);
-      shadowRef.current = text;
-      revRef.current = newRev;
-    })
-    channel.on("code:error", ({reason}: {reason: string}) => console.log("error: " + reason));
-    channel.on("code:stale", () => {
-      console.log("Stale revision, requesting snapshot");
-      channel.push("code:request_snapshot", {})
-    })
+		channel
+			.join()
+			.receive("ok", (resp: SessionJoinResponse) => {
+				console.log("Joined successfully", resp);
 
+				revRef.current = resp.rev || 0;
+				const initialText = resp.text || "";
+				shadowRef.current = initialText;
 
-    // Cleanup on unmount
-    return () => {
-      console.log("Cleaning up socket");
-      
-      channel.off("code:update");
-      channel.off("code:snapshot");
-      channel.off("code:error");
-      channel.off("code:stale");
-      channel.leave();
-      socket.disconnect();
-    }
-  }, [])
+				if (editorRef.current) {
+					updateEditorContent(initialText);
+				}
+			})
+			.receive("error", (resp: { resp: { reason: string } }) => {
+				console.log("Unable to join", resp);
+			});
 
-  const handleCodeChange = (value: string | undefined) => {
-    if (localApply.current) {
-      localApply.current = false;
-      console.log("Skipping programmatic change");
-      return;
-    }
-    const newCode = value || "";
+		channel.on("code:update", (response: CodeUpdateResponse) => {
+			console.log("Update response:", response);
+			const { rev: newRev, delta, by } = response;
+			revRef.current = newRev;
 
-    if (channelRef.current) {
-      const { from, to, text } = computeCodeDiff(shadowRef.current, newCode);
-      if (from !== to || text !== "") {
-        channelRef.current.push("code:delta", { from, to, text, rev: revRef.current });
-      }
-    }
-  }
+			if (by !== user?.id) {
+				const shadowLeft = shadowRef.current.slice(0, delta.from);
+				const shadowRight = shadowRef.current.slice(delta.to);
+				shadowRef.current = shadowLeft + delta.text + shadowRight;
 
-  return (
-    <div className="flex flex-col gap-2">
-      <div className="rounded-md overflow-hidden w-full h-full shadow-4xl py-2 bg-[#1E1E1E]">
-        <Editor
-          height="50vh"
-          theme="vs-dark"
-          language={language}
-          value={code}
-          onChange={(value: string | undefined) => handleCodeChange(value)}
-        />
-      </div>
-      <div className="flex items-center">
-        <UsersIcon className="h-4 w-4 text-gray-500 mr-1" />
-        <div className="text-sm text-gray-500">2 users editing</div>
-        <button className="ml-auto cursor-pointer bg-blue-500 hover:bg-blue-600/90 active:bg-blue-700 flex items-center justify-center text-white text-sm px-3 py-2 rounded-lg gap-3">
-          <PlayIcon className="h-4 w-4" /> Run Solution
-        </button>
-      </div>
-    </div>
-  );
+				// Get current content directly from editor
+				const currentCode = editorRef.current?.getValue() || "";
+				const left = currentCode.slice(0, delta.from);
+				const right = currentCode.slice(delta.to);
+				const newCode = left + delta.text + right;
+
+				// Update content while preserving cursor
+				console.log("new code", newCode);
+				updateEditorContent(newCode);
+			}
+		});
+		channel.on(
+			"code:snapshot",
+			({ rev: newRev, text }: { rev: number; text: string }) => {
+				console.log("received snapshot", text);
+				updateEditorContent(text);
+				shadowRef.current = text;
+				revRef.current = newRev;
+			},
+		);
+
+		channel.on("code:error", ({ reason }: { reason: string }) =>
+			console.log(`error: ${reason}`),
+		);
+		channel.on("code:stale", () => {
+			console.log("Stale revision, requesting snapshot");
+			channel.push("code:request_snapshot", {});
+		});
+
+		return () => {
+			console.log("Cleaning up socket");
+			channel.off("code:update");
+			channel.off("code:snapshot");
+			channel.off("code:error");
+			channel.off("code:stale");
+			channel.leave();
+			socket.disconnect();
+		};
+	}, [token, updateEditorContent, user]);
+
+	const handleCodeChange = (value: string | undefined) => {
+		if (localApply.current) {
+			localApply.current = false;
+			return;
+		}
+
+		const newCode = value || "";
+
+		if (channelRef.current) {
+			const { from, to, text } = computeCodeDiff(shadowRef.current, newCode);
+			if (from !== to || text !== "") {
+				localApply.current = true;
+				channelRef.current.push("code:delta", {
+					from,
+					to,
+					text,
+					rev: revRef.current,
+				});
+				shadowRef.current = newCode;
+			}
+		}
+	};
+
+	return (
+		<div className="flex flex-col gap-2">
+			<div className="rounded-md overflow-hidden w-full h-full shadow-4xl py-2 bg-[#1E1E1E]">
+				<Editor
+					height="50vh"
+					theme="vs-dark"
+					language={language}
+					onChange={handleCodeChange}
+					onMount={handleEditorDidMount}
+					options={{
+						cursorSmoothCaretAnimation: "on",
+						smoothScrolling: true,
+					}}
+				/>
+			</div>
+			<div className="flex items-center">
+				<UsersIcon className="h-4 w-4 text-gray-500 mr-1" />
+				<div className="text-sm text-gray-500">2 users editing</div>
+				<button
+					type="button"
+					className="ml-auto cursor-pointer bg-blue-500 hover:bg-blue-600/90 active:bg-blue-700 flex items-center justify-center text-white text-sm px-3 py-2 rounded-lg gap-3"
+				>
+					<PlayIcon className="h-4 w-4" /> Run Solution
+				</button>
+			</div>
+		</div>
+	);
 };

--- a/frontend/src/pages/Session/components/SessionQuestion/components/SessionEditor.tsx
+++ b/frontend/src/pages/Session/components/SessionQuestion/components/SessionEditor.tsx
@@ -1,6 +1,9 @@
 import { Editor } from "@monaco-editor/react";
 import { PlayIcon, UsersIcon } from "lucide-react";
-import { useState } from "react";
+import { Channel, Socket } from "phoenix";
+import { useEffect, useState, useRef } from "react";
+import { useAuth } from "../../../../../context/AuthContext";
+import { computeCodeDiff } from "../../../../../utils";
 
 interface SessionEditorProps {
   language?: string;
@@ -8,7 +11,114 @@ interface SessionEditorProps {
 export const SessionEditor = ({
   language = "javascript",
 }: SessionEditorProps) => {
-  const [code, setCode] = useState("// Start coding here...");
+  const [code, setCode] = useState("");
+  const { user } = useAuth();
+
+  // Helper values that should not trigger rerenders
+  const revRef = useRef(0);
+  const shadowRef = useRef("");
+  const localApply = useRef(false);
+
+  // Refs for connection that should persist 
+  const socketRef = useRef<Socket | null>(null);
+  const channelRef = useRef<Channel | null>(null);
+
+  const WEB_SOCKET_URL = 'ws://localhost:4000/ws';
+  const token = '';
+  const sessionId = '';
+
+  // Init and join the channel on mount
+  useEffect(() => {
+    const socket = new Socket(WEB_SOCKET_URL, {
+      params: { token: token },
+    });
+    socket.connect();
+    socketRef.current = socket;
+
+    const channel = socket.channel(`session:${sessionId}`);
+    channelRef.current = channel;
+
+    // TODO: Type properly
+    channel.join().receive("ok", (resp: any) => {
+      console.log("Joined successfully", resp);
+
+      revRef.current = resp.rev || 0;
+      const initialText = resp.text || "";
+      shadowRef.current = initialText;
+
+      localApply.current = true;
+      setCode(initialText);
+    }).receive("error", (resp: any) => {
+      console.log("Unable to join", resp);
+    });
+
+    // TODO: Type properly
+    // Initialise update listener (only once)
+    channel.on("code:update", (response: any) => {
+      console.log("Update response:", response);
+      const { rev: newRev, delta, by } = response;
+      revRef.current = newRev;
+
+      const shadowLeft = shadowRef.current.slice(0, delta.from);
+      const shadowRight = shadowRef.current.slice(delta.to);
+      shadowRef.current = shadowLeft + delta.text + shadowRight;
+          
+
+      if (by !== user?.id) {
+        localApply.current = true;
+        setCode(currentCode => {
+          console.log("currentCode:", currentCode);
+          console.log("Delta:", delta);
+          const left = currentCode.slice(0, delta.from);
+          const right = currentCode.slice(delta.to);
+          const newCode = left + delta.text + right;
+          
+          return newCode;
+        });
+      }
+    })
+    channel.on("code:snapshot", ({rev: newRev, text}: {rev: number, text: string}) => {
+      localApply.current = true;
+      setCode(text);
+      shadowRef.current = text;
+      revRef.current = newRev;
+    })
+    channel.on("code:error", ({reason}: {reason: string}) => console.log("error: " + reason));
+    channel.on("code:stale", () => {
+      console.log("Stale revision, requesting snapshot");
+      channel.push("code:request_snapshot", {})
+    })
+
+
+    // Cleanup on unmount
+    return () => {
+      console.log("Cleaning up socket");
+      
+      channel.off("code:update");
+      channel.off("code:snapshot");
+      channel.off("code:error");
+      channel.off("code:stale");
+      channel.leave();
+      socket.disconnect();
+    }
+  }, [])
+
+  const handleCodeChange = (value: string | undefined) => {
+    if (localApply.current) {
+      localApply.current = false;
+      console.log("Skipping programmatic change");
+      return;
+    }
+    const newCode = value || "";
+
+    if (channelRef.current) {
+      const { from, to, text } = computeCodeDiff(shadowRef.current, newCode);
+      if (from !== to || text !== "") {
+        channelRef.current.push("code:delta", { from, to, text, rev: revRef.current });
+      }
+    }
+  }
+
   return (
     <div className="flex flex-col gap-2">
       <div className="rounded-md overflow-hidden w-full h-full shadow-4xl py-2 bg-[#1E1E1E]">
@@ -17,7 +127,7 @@ export const SessionEditor = ({
           theme="vs-dark"
           language={language}
           value={code}
-          onChange={(value: string | undefined) => setCode(value || "")}
+          onChange={(value: string | undefined) => handleCodeChange(value)}
         />
       </div>
       <div className="flex items-center">

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -1,17 +1,35 @@
 export interface User {
-  id: string;
-  username: string;
-  email: string;
-  isAdmin: boolean;
-  createdAt: string;
+	id: string;
+	username: string;
+	email: string;
+	isAdmin: boolean;
+	createdAt: string;
 }
 
 export interface VerifyTokenResponse {
-  message: string;
-  data: User;
+	message: string;
+	data: User;
 }
 
 export interface LoginResponse {
-  message: string;
-  data: User & { accessToken: string };
+	message: string;
+	data: User & { accessToken: string };
 }
+
+export type SessionJoinResponse = {
+	user_id: string;
+	rev: number;
+	text: string;
+};
+
+export type Delta = {
+	from: number;
+	to: number;
+	text: string;
+};
+
+export type CodeUpdateResponse = {
+	rev: number;
+	delta: Delta;
+	by: string;
+};

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -5,3 +5,26 @@ import { twMerge } from "tailwind-merge";
 export const twcn = (...args: ClassValue[]) => {
   return twMerge(cn(...args));
 };
+
+// compute a minimal {from,to,text} by LCP/LCSuffix against previous value
+export const computeCodeDiff = (oldText: string, newText: string) => {
+  if (oldText === newText) {
+    return { from: 0, to: 0, text: "" };
+  }
+  let start = 0;
+  while (start < oldText.length && start < newText.length && oldText[start] === newText[start]) {
+    start++;
+  }
+  let oldEnd = oldText.length - 1;
+  let newEnd = newText.length - 1;
+  while (oldEnd >= start && newEnd >= start && oldText[oldEnd] === newText[newEnd]) {
+    oldEnd--;
+    newEnd--;
+  }
+  
+  return {
+    from: start,
+    to: oldEnd + 1,
+    text: newText.slice(start, newEnd + 1)
+  };
+};

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -6,18 +6,24 @@ export const twcn = (...args: ClassValue[]) => {
   return twMerge(cn(...args));
 };
 
-// compute a minimal {from,to,text} by LCP/LCSuffix against previous value
 export const computeCodeDiff = (oldText: string, newText: string) => {
-  if (oldText === newText) {
+  // Normalize line endings to handle newlines
+  const oldNormalized = oldText.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const newNormalized = newText.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  
+  if (oldNormalized === newNormalized) {
     return { from: 0, to: 0, text: "" };
   }
+  
   let start = 0;
-  while (start < oldText.length && start < newText.length && oldText[start] === newText[start]) {
+  while (start < oldNormalized.length && start < newNormalized.length && oldNormalized[start] === newNormalized[start]) {
     start++;
   }
-  let oldEnd = oldText.length - 1;
-  let newEnd = newText.length - 1;
-  while (oldEnd >= start && newEnd >= start && oldText[oldEnd] === newText[newEnd]) {
+  
+  let oldEnd = oldNormalized.length - 1;
+  let newEnd = newNormalized.length - 1;
+  
+  while (oldEnd >= start && newEnd >= start && oldNormalized[oldEnd] === newNormalized[newEnd]) {
     oldEnd--;
     newEnd--;
   }
@@ -25,6 +31,6 @@ export const computeCodeDiff = (oldText: string, newText: string) => {
   return {
     from: start,
     to: oldEnd + 1,
-    text: newText.slice(start, newEnd + 1)
+    text: newNormalized.slice(start, newEnd + 1)
   };
 };


### PR DESCRIPTION
This PR implements the following changes:
- Update collab-service to verify JWT tokens via an API call to user service
- Update websocket to use actual user authToken
- Migrate and adapt `collab-client.html` file to `SessionEditor.tsx`
- Update monaco editor to be an uncontrolled components for consistency of text and cursor position

Future improvements:
- Currently the consecutive edits lag by 1 edit (e.g. userA types '1' -> userA editor: '1', userB: '' -> userA types 2 -> userA editor: '12', userB: '12'). This could be due to a mishandling of refs/states - will have to trouble someone else to help to check and see if anything looks off
- Debounce/throttling of updates to improve performance when typing speed is fast
